### PR TITLE
Displaying failed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ This boilerplate includes the [Meta Sync Plugin](https://github.com/serverless/s
 - Install [Docker](https://www.docker.com/)
 - Run `docker-compose up` to install and run DynamoDB.
 - Add the `localDynamoDbEndpoint` variable with the value `http://<DOCKER-MACHINE-IP>:8000` to `_meta/variables/s-variables-common.json`. Example value:  `http://192.168.99.100:8000`.
-- Run `sls setup db -s <stage> -r <region>` to create tables in the local DynamoDB instance. Notice that local DynamoDB is started with -inMemory parameter and when it is stopped no data will be saved.
+- Run `sls setup db -s <stage> -r <region>` to create tables in the local DynamoDB instance.
 - Run `sls offline start` to start [the offline server](https://github.com/dherault/serverless-offline).
 
 ### Running Tests
-- Follow the _Testing With A Local DynamoDB Instance_ instructions. Starting the offline server is not necessary.
+- Follow the _Testing With A Local DynamoDB Instance_ instructions. Starting the offline server is not necessary. Notice that local DynamoDB is started with -inMemory parameter and no data will be saved when it is stopped.
 - Check that package.json script/test has the same stage and region defined as the DynamoDb table created in the last step.
 - Run `npm test`.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This boilerplate includes the [Meta Sync Plugin](https://github.com/serverless/s
 - Install [Docker](https://www.docker.com/)
 - Run `docker-compose up` to install and run DynamoDB.
 - Add the `localDynamoDbEndpoint` variable with the value `http://<DOCKER-MACHINE-IP>:8000` to `_meta/variables/s-variables-common.json`. Example value:  `http://192.168.99.100:8000`.
-- Run `sls setup db -s <stage> -r <region>` to create tables in the local DynamoDB instance.
+- Run `sls setup db -s <stage> -r <region>` to create tables in the local DynamoDB instance. Notice that local DynamoDB is started with -inMemory parameter and when it is stopped no data will be saved.
 - Run `sls offline start` to start [the offline server](https://github.com/dherault/serverless-offline).
 
 ### Running Tests

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,5 +1,8 @@
+'use strict';
+
 const chai = require('chai');
 const commonVariables = require('../_meta/variables/s-variables-common.json');
+const _ = require('lodash');
 
 process.env.LOCAL_DDB_ENDPOINT = commonVariables.localDynamoDbEndpoint;
 process.env.SERVERLESS_PROJECT = commonVariables.project;
@@ -9,3 +12,9 @@ process.env.IS_OFFLINE = true;
 chai.config.includeStack = true;
 
 global.expect = chai.expect;
+
+global.combineErrors = (errors, error) => {
+  return !_.isEmpty(errors) ? new Error(_.map(errors, (error) => {
+    return error.message
+  })) : error;
+};

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -9,12 +9,36 @@ process.env.SERVERLESS_PROJECT = commonVariables.project;
 process.env.AUTH_TOKEN_SECRET = 'secret-token-1';
 process.env.IS_OFFLINE = true;
 
-chai.config.includeStack = true;
+chai.config.includeStack = false;
+chai.config.showDiff = false;
 
 global.expect = chai.expect;
 
+/**
+ * combines response errors and error
+ * @param errors
+ * @param error
+ * @returns Error
+ */
 global.combineErrors = (errors, error) => {
-  return !_.isEmpty(errors) ? new Error(_.map(errors, (error) => {
-    return error.message
-  })) : error;
+  let err = !_.isEmpty(errors) ? _.map(errors, (error) => {
+    if(error.originalError instanceof Error){
+      return error.originalError
+    } else {
+      return new Error(error.originalError);
+    }
+  }) : error;
+
+  if(_.isArray(err)){
+    if(err.length == 1){
+      // take first error from response errors
+      return _.first(err);
+    } else {
+      // multiple errors from response
+      return new Error(err.join());
+    }
+  } else {
+      return err;
+  }
 };
+

--- a/tests/users.spec.js
+++ b/tests/users.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const handler = require('../back/api/data/handler').handler;
-const _ = require('lodash');
 
 describe('Users', () => {
   let token;
@@ -13,13 +12,15 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        let user = response.data.createUser;
-        expect(user.username).to.equal('testuser');
-        expect(user.name).to.equal('Test User');
-        expect(user.email).to.equal('testuser@serverless.com');
-        expect(user.token).to.be.null;
-        expect(response.errors).to.be.empty;
-        done(error);
+        let errors = combineErrors(response.errors, error);
+        if (!errors) {
+          let user = response.data.createUser;
+          expect(user.username).to.equal('testuser');
+          expect(user.name).to.equal('Test User');
+          expect(user.email).to.equal('testuser@serverless.com');
+          expect(user.token).to.be.null;
+        }
+        done(errors);
       });
     });
   });
@@ -31,9 +32,11 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        expect(response.data.users).to.have.lengthOf(1);
-        expect(response.errors).to.be.empty;
-        done(error);
+        let errors = combineErrors(response.errors, error);
+        if (!errors) {
+          expect(response.data.users).to.have.lengthOf(1);
+        }
+        done(errors);
       });
     });
 
@@ -43,13 +46,15 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        let user = response.data.user;
-        expect(user.username).to.equal('testuser');
-        expect(user.name).to.equal('Test User');
-        expect(user.email).to.equal('testuser@serverless.com');
-        expect(user.token).to.be.null;
-        expect(response.errors).to.be.empty;
-        done(error);
+        let errors = combineErrors(response.errors, error);
+        if (!errors) {
+          let user = response.data.user;
+          expect(user.username).to.equal('testuser');
+          expect(user.name).to.equal('Test User');
+          expect(user.email).to.equal('testuser@serverless.com');
+          expect(user.token).to.be.null;
+        }
+        done(errors);
       });
     });
   });
@@ -61,8 +66,13 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        expect(response.errors[0].message).to.equal('User not found');
-        done(error);
+        let expectedError = response.errors[0];
+        let errors = combineErrors(response.errors, error);
+        if (!error && expectedError.message === 'User not found') {
+          done(null);
+        } else {
+          done(errors);
+        }
       });
     });
 
@@ -72,8 +82,13 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        expect(response.errors[0].message).to.equal('invalid password');
-        done(error);
+        let expectedError = response.errors[0];
+        let errors = combineErrors(response.errors, error);
+        if (!error && expectedError.message === 'invalid password') {
+          done(null);
+        } else {
+          done(errors);
+        }
       });
     });
 
@@ -83,14 +98,16 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        let user = response.data.loginUser;
-        token = user.token;
-        expect(user.username).to.equal('testuser');
-        expect(user.name).to.equal('Test User');
-        expect(user.email).to.equal('testuser@serverless.com');
-        expect(user.token).not.to.be.null;
-        expect(response.errors).to.be.empty;
-        done(error);
+        let errors = combineErrors(response.errors, error);
+        if (!errors) {
+          let user = response.data.loginUser;
+          token = user.token;
+          expect(user.username).to.equal('testuser');
+          expect(user.name).to.equal('Test User');
+          expect(user.email).to.equal('testuser@serverless.com');
+          expect(user.token).not.to.be.null;
+        }
+        done(errors);
       });
     });
   });
@@ -102,8 +119,13 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        expect(response.errors[0].message).to.equal('Invalid Token');
-        done(error);
+        let expectedError = response.errors[0];
+        let errors = combineErrors(response.errors, error);
+        if (!error && expectedError.message === 'Invalid Token') {
+          done(null);
+        } else {
+          done(errors);
+        }
       });
     });
 
@@ -113,11 +135,13 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        let user = response.data.updateUser;
-        expect(user.name).to.equal('New Name');
-        expect(user.email).to.equal('newuser@serverless.com');
-        expect(response.errors).to.be.empty;
-        done(error);
+        let errors = combineErrors(response.errors, error);
+        if (!errors) {
+          let user = response.data.updateUser;
+          expect(user.name).to.equal('New Name');
+          expect(user.email).to.equal('newuser@serverless.com');
+        }
+        done(errors);
       });
     });
   });
@@ -129,8 +153,13 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        expect(response.errors[0].message).to.equal('Invalid Token');
-        done(error);
+        let expectedError = response.errors[0];
+        let errors = combineErrors(response.errors, error);
+        if (!error && expectedError.message === 'Invalid Token') {
+          done(null);
+        } else {
+          done(errors);
+        }
       });
     });
 
@@ -140,14 +169,16 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        let user = response.data.deleteUser;
-        expect(user.id).to.be.null;
-        expect(user.username).to.be.null;
-        expect(user.name).to.be.null;
-        expect(user.email).to.be.null;
-        expect(user.token).to.be.null;
-        expect(response.errors).to.be.empty;
-        done(error);
+        let errors = combineErrors(response.errors, error);
+        if (!errors) {
+          let user = response.data.deleteUser;
+          expect(user.id).to.be.null;
+          expect(user.username).to.be.null;
+          expect(user.name).to.be.null;
+          expect(user.email).to.be.null;
+          expect(user.token).to.be.null;
+        }
+        done(errors);
       });
     });
 
@@ -157,9 +188,11 @@ describe('Users', () => {
       };
 
       handler(event, null, (error, response) => {
-        expect(response.data.users).to.be.empty;
-        expect(response.errors).to.be.empty;
-        done(error);
+        let errors = combineErrors(response.errors, error);
+        if (!errors) {
+          expect(response.data.users).to.be.empty;
+        }
+        done(errors);
       });
     });
   });

--- a/tests/users.spec.js
+++ b/tests/users.spec.js
@@ -14,11 +14,15 @@ describe('Users', () => {
       handler(event, null, (error, response) => {
         let errors = combineErrors(response.errors, error);
         if (!errors) {
-          let user = response.data.createUser;
-          expect(user.username).to.equal('testuser');
-          expect(user.name).to.equal('Test User');
-          expect(user.email).to.equal('testuser@serverless.com');
-          expect(user.token).to.be.null;
+          try {
+            let user = response.data.createUser;
+            expect(user.username).to.equal('testuser');
+            expect(user.name).to.equal('Test User');
+            expect(user.email).to.equal('testuser@serverless.com');
+            expect(user.token).to.be.null;
+          } catch (exception) {
+            errors = exception;
+          }
         }
         done(errors);
       });
@@ -34,7 +38,11 @@ describe('Users', () => {
       handler(event, null, (error, response) => {
         let errors = combineErrors(response.errors, error);
         if (!errors) {
-          expect(response.data.users).to.have.lengthOf(1);
+          try {
+            expect(response.data.users).to.have.lengthOf(1);
+          } catch (exception) {
+            errors = exception;
+          }
         }
         done(errors);
       });
@@ -48,11 +56,15 @@ describe('Users', () => {
       handler(event, null, (error, response) => {
         let errors = combineErrors(response.errors, error);
         if (!errors) {
-          let user = response.data.user;
-          expect(user.username).to.equal('testuser');
-          expect(user.name).to.equal('Test User');
-          expect(user.email).to.equal('testuser@serverless.com');
-          expect(user.token).to.be.null;
+          try {
+            let user = response.data.user;
+            expect(user.username).to.equal('testuser');
+            expect(user.name).to.equal('Test User');
+            expect(user.email).to.equal('testuser@serverless.com');
+            expect(user.token).to.be.null;
+          } catch (exception) {
+            errors = exception;
+          }
         }
         done(errors);
       });
@@ -100,12 +112,16 @@ describe('Users', () => {
       handler(event, null, (error, response) => {
         let errors = combineErrors(response.errors, error);
         if (!errors) {
-          let user = response.data.loginUser;
-          token = user.token;
-          expect(user.username).to.equal('testuser');
-          expect(user.name).to.equal('Test User');
-          expect(user.email).to.equal('testuser@serverless.com');
-          expect(user.token).not.to.be.null;
+          try {
+            let user = response.data.loginUser;
+            token = user.token;
+            expect(user.username).to.equal('testuser');
+            expect(user.name).to.equal('Test User');
+            expect(user.email).to.equal('testuser@serverless.com');
+            expect(user.token).not.to.be.null;
+          } catch (exception) {
+            errors = exception;
+          }
         }
         done(errors);
       });
@@ -115,7 +131,7 @@ describe('Users', () => {
   describe('Update', () => {
     it('should not update name and email with bad token', (done) => {
       let event = {
-        "query": "mutation updateUserTest {updateUser (name: \"User New Name\", email: \"newtestuser@serverless.com\", password: \"secret\", token: \"bad-token\"){id username name email token}}"
+        "query": "mutation updateUserTest {updateUser (name: \"New Name\", email: \"newuser@serverless.com\", password: \"secret\", token: \"bad-token\"){id username name email token}}"
       };
 
       handler(event, null, (error, response) => {
@@ -137,9 +153,13 @@ describe('Users', () => {
       handler(event, null, (error, response) => {
         let errors = combineErrors(response.errors, error);
         if (!errors) {
-          let user = response.data.updateUser;
-          expect(user.name).to.equal('New Name');
-          expect(user.email).to.equal('newuser@serverless.com');
+          try {
+            let user = response.data.updateUser;
+            expect(user.name).to.equal('New Name');
+            expect(user.email).to.equal('newuser@serverless.com');
+          } catch (exception) {
+            errors = exception;
+          }
         }
         done(errors);
       });
@@ -171,12 +191,16 @@ describe('Users', () => {
       handler(event, null, (error, response) => {
         let errors = combineErrors(response.errors, error);
         if (!errors) {
-          let user = response.data.deleteUser;
-          expect(user.id).to.be.null;
-          expect(user.username).to.be.null;
-          expect(user.name).to.be.null;
-          expect(user.email).to.be.null;
-          expect(user.token).to.be.null;
+          try {
+            let user = response.data.deleteUser;
+            expect(user.id).to.be.null;
+            expect(user.username).to.be.null;
+            expect(user.name).to.be.null;
+            expect(user.email).to.be.null;
+            expect(user.token).to.be.null;
+          } catch (exception) {
+            errors = exception;
+          }
         }
         done(errors);
       });
@@ -190,7 +214,11 @@ describe('Users', () => {
       handler(event, null, (error, response) => {
         let errors = combineErrors(response.errors, error);
         if (!errors) {
-          expect(response.data.users).to.be.empty;
+          try {
+            expect(response.data.users).to.be.empty;
+          } catch (exception) {
+            errors = exception;
+          }
         }
         done(errors);
       });


### PR DESCRIPTION

This PR improves the way errors are displayed when a test fails. AssertionError and response errors combined with callback error are passed to the Mocha done function.

Before
Most of the failures threw a timeout error:
```
1) Users Create should create a user:
   Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```

After
When expectation doesn't meet response:
```
1) Users Create should create a user:
   AssertionError: expected 'testuser' to equal 'testuser-123'
```

When database table is not created or functional:
```
1) Users Create should create a user:
   ResourceNotFoundException: Cannot do operations on a non-existent table