### PR TITLE
Generate config var values as strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ coverage/
 build/
 api/graphql
 api/config.js
+
+# vim
+*.swp

--- a/foundation/generateConfig/index.js
+++ b/foundation/generateConfig/index.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 const content = `module.exports = {
-  AUTH_CLIENT_SECRET: ${process.env.AUTH_CLIENT_SECRET},
-  AUTH_CLIENT_ID: ${process.env.AUTH_CLIENT_ID},
+  AUTH_CLIENT_SECRET: '${process.env.AUTH_CLIENT_SECRET}',
+  AUTH_CLIENT_ID: '${process.env.AUTH_CLIENT_ID}',
 };
 `;
 

--- a/foundation/generateConfig/index.js
+++ b/foundation/generateConfig/index.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 const content = `module.exports = {
-  AUTH_CLIENT_SECRET: '${process.env.AUTH_CLIENT_SECRET}',
-  AUTH_CLIENT_ID: '${process.env.AUTH_CLIENT_ID}',
+  AUTH_CLIENT_SECRET: '${process.env.AUTH_CLIENT_SECRET || ""}',
+  AUTH_CLIENT_ID: '${process.env.AUTH_CLIENT_ID || ""}',
 };
 `;
 


### PR DESCRIPTION
Not sure if this is desired, but...

Currently running foundation/generateConfig/index.js outputs env var values as variables due to the way it writes to file.

ex:

```
$ export AUTH_CLIENT_SECRET="abc123" && npm run generate:config
```

will generate

```
module.exports = {
  AUTH_CLIENT_SECRET: abc123,
  AUTH_CLIENT_ID: undefined,
};
```

This PR will interpolate the env vars as strings. Note that if an env is undefined, the written value will be an empty string `""` which imo looks better than `"undefined"`.

```
$ export AUTH_CLIENT_SECRET="abc123" && npm run generate:config
```

will now generate

```
module.exports = {
  AUTH_CLIENT_SECRET: 'abc123',
  AUTH_CLIENT_ID: '',
};
```
