### PR TITLE
Corrected syntax error in serverless.yaml for Access-Controll-Allow-Origin

### DIFF
--- a/api/serverless.yaml
+++ b/api/serverless.yaml
@@ -19,7 +19,7 @@ functions:
         cors: true
         response:
           headers:
-            Access-Control-Allow-Origin: "*"
+            Access-Control-Allow-Origin: "'*'"
 
 resources:
   Resources:


### PR DESCRIPTION
Without the single quotes around the wild-card value * serverless deploy failed with the following error:

<img width="592" alt="screen shot 2016-11-02 at 10 46 18 pm" src="https://cloud.githubusercontent.com/assets/2458150/19954497/15a4a23e-a14f-11e6-9cad-596ac5fe8a89.png">
