### PR TITLE
[docs] Fix example path for S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You need to make sure you have access to your deployed lambda functions.
 
   - Now, in `app-client/<client-name>/serverless.yml` edit the `custom.client.bucketName` property and replace it the bucket name above.
 
-  - Now, in `app-client/<client-name>/package.json` edit the `homepage` property with `https://s3.amazonaws.com/${yourBucketName}`. For ex: https://s3.amazonaws.com/s3-firstname-serverless-graphql-apollo
+  - Now, in `app-client/<client-name>/package.json` edit the `homepage` property with `https://${yourBucketName}.s3-website-us-east-1.amazonaws.com`. For ex: http://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com
 
   - Run the deployment command
       ```

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ You need to make sure you have access to your deployed lambda functions.
 
   - Now, in `app-client/<client-name>/serverless.yml` edit the `custom.client.bucketName` property and replace it the bucket name above.
 
-  - Now, in `app-client/<client-name>/package.json` edit the `homepage` property with `https://${yourBucketName}.s3-website-us-east-1.amazonaws.com`. For ex: http://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com
+  - Now, in `app-client/<client-name>/package.json` edit the `homepage` property with `https://${yourBucketName}.s3-website-us-east-1.amazonaws.com`. For ex: https://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com
 
   - Run the deployment command
       ```

--- a/app-client/apollo-client/package.json
+++ b/app-client/apollo-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app-client",
   "homepage":
-    "https://s3.amazonaws.com/s3-bucketname-serverless-graphql-apollo",
+    "http://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/app-client/apollo-client/package.json
+++ b/app-client/apollo-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app-client",
   "homepage":
-    "http://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com",
+    "https://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/app-client/appsync-client/package.json
+++ b/app-client/appsync-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app-client",
   "homepage":
-    "https://s3.amazonaws.com/s3-bucketname-serverless-graphql-apollo",
+    "http://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/app-client/appsync-client/package.json
+++ b/app-client/appsync-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app-client",
   "homepage":
-    "http://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com",
+    "https://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This confused me when I read the `README.md` and tried to deploy for myself and the CSS path gave 404.

It's also the reason why the actual example build is also giving error [here](https://s3.amazonaws.com/s3-firstname-serverless-graphql-apollo) (link from current README) where as it is actually deployed to [here](http://s3-bucketname-serverless-graphql-apollo.s3-website-us-east-1.amazonaws.com/index.html) and misconfiguration is resulting is 404 for the path of the CSS. 

/edit: no idea why tests would fail - did not touch code!