### PR TITLE
Make User tweets limit not required for dynamodb backend

### DIFF
--- a/app-backend/dynamodb/schema.js
+++ b/app-backend/dynamodb/schema.js
@@ -93,7 +93,7 @@ type User {
     favourites_count: Int!
     following: [String!]!
     topTweet: Tweet
-    tweets(limit: Int!, nextToken: TokenInput): TweetConnection
+    tweets(limit: Int, nextToken: TokenInput): TweetConnection
 
     # search functionality is available in elasticsearch integration
     searchTweetsByKeyword(keyword: String!): TweetConnection


### PR DESCRIPTION
Tweets argument "limit" is set as required in the dynamodb backend schema.  This causes the app-client to not work, and throws errors on the queries shown in the example:
https://github.com/serverless/serverless-graphql/blame/master/README.md#L125

Other schema files match the not required limit convention: 
https://github.com/serverless/serverless-graphql/blob/master/app-backend/rds/schema.js#L84 
