### PR TITLE
Removed polyfill from dynamodb handler

### DIFF
--- a/app-backend/dynamodb/handler.js
+++ b/app-backend/dynamodb/handler.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import { graphqlLambda, graphiqlLambda } from 'apollo-server-lambda';
 import lambdaPlayground from 'graphql-playground-middleware-lambda';
 import { makeExecutableSchema } from 'graphql-tools';


### PR DESCRIPTION
This was causing Error: only one instance of babel-polyfill is allowed 