### PR TITLE
use AWS sdk promise in resolver

### DIFF
--- a/app-backend/dynamodb/resolvers.js
+++ b/app-backend/dynamodb/resolvers.js
@@ -1,6 +1,5 @@
 // add to handler.js
 import dynamodb from 'serverless-dynamodb-client';
-
 let docClient;
 
 if (process.env.NODE_ENV === 'production') {
@@ -11,110 +10,89 @@ if (process.env.NODE_ENV === 'production') {
   docClient = dynamodb.doc;
 }
 
-// add to handler.js
-const promisify = foo =>
-  new Promise((resolve, reject) => {
-    foo((error, result) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(result);
-      }
-    });
-  });
-
 const data = {
-  getPaginatedTweets(handle, args) {
-    return promisify(callback => {
-      const params = {
-        TableName: 'Tweets',
-        KeyConditionExpression: 'handle = :v1',
-        ExpressionAttributeValues: {
-          ':v1': handle,
-        },
-        IndexName: 'tweet-index',
-        Limit: args.limit,
-        ScanIndexForward: false,
+  async getPaginatedTweets(handle, args) {
+    const params = {
+      TableName: 'Tweets',
+      KeyConditionExpression: 'handle = :v1',
+      ExpressionAttributeValues: {
+        ':v1': handle,
+      },
+      IndexName: 'tweet-index',
+      Limit: args.limit,
+      ScanIndexForward: false,
+    };
+
+    if (args.nextToken) {
+      params.ExclusiveStartKey = {
+        tweet_id: args.nextToken.tweet_id,
+        created_at: args.nextToken.created_at,
+        handle: handle,
       };
+    }
+    const result = await docClient.query(params).promise()
+    const tweets = [];
+    let listOfTweets;
 
-      if (args.nextToken) {
-        params.ExclusiveStartKey = {
-          tweet_id: args.nextToken.tweet_id,
-          created_at: args.nextToken.created_at,
-          handle: handle,
-        };
-      }
+    console.log(result);
 
-      docClient.query(params, callback);
-    }).then(result => {
-      const tweets = [];
-      let listOfTweets;
+    if (result.Items.length >= 1) {
+      listOfTweets = {
+        items: [],
+      };
+    }
 
-      console.log(result);
+    for (let i = 0; i < result.Items.length; i += 1) {
+      tweets.push({
+        tweet_id: result.Items[i].tweet_id,
+        created_at: result.Items[i].created_at,
+        handle: result.Items[i].handle,
+        tweet: result.Items[i].tweet,
+        retweet_count: result.Items[i].retweet_count,
+        retweeted: result.Items[i].retweeted,
+        favorited: result.Items[i].favorited,
+      });
+    }
 
-      if (result.Items.length >= 1) {
-        listOfTweets = {
-          items: [],
-        };
-      }
+    listOfTweets.items = tweets;
 
-      for (let i = 0; i < result.Items.length; i += 1) {
-        tweets.push({
-          tweet_id: result.Items[i].tweet_id,
-          created_at: result.Items[i].created_at,
-          handle: result.Items[i].handle,
-          tweet: result.Items[i].tweet,
-          retweet_count: result.Items[i].retweet_count,
-          retweeted: result.Items[i].retweeted,
-          favorited: result.Items[i].favorited,
-        });
-      }
+    if (result.LastEvaluatedKey) {
+      listOfTweets.nextToken = {
+        tweet_id: result.LastEvaluatedKey.tweet_id,
+        created_at: result.LastEvaluatedKey.created_at,
+        handle: result.LastEvaluatedKey.handle,
+      };
+    }
 
-      listOfTweets.items = tweets;
-
-      if (result.LastEvaluatedKey) {
-        listOfTweets.nextToken = {
-          tweet_id: result.LastEvaluatedKey.tweet_id,
-          created_at: result.LastEvaluatedKey.created_at,
-          handle: result.LastEvaluatedKey.handle,
-        };
-      }
-
-      return listOfTweets;
-    });
+    return listOfTweets;
   },
-  getUserInfo(args) {
-    return promisify(callback =>
-      docClient.query(
-        {
-          TableName: 'Users',
-          KeyConditionExpression: 'handle = :v1',
-          ExpressionAttributeValues: {
-            ':v1': args.handle,
-          },
-        },
-        callback
-      )
-    ).then(result => {
-      let listOfTweets;
+  async getUserInfo(args) {
+    const params = {
+      TableName: 'Users',
+      KeyConditionExpression: 'handle = :v1',
+      ExpressionAttributeValues: {
+        ':v1': args.handle,
+      },
+    };
+    const result = await docClient.query(params).promise()
+    let listOfTweets;
 
-      if (result.Items.length >= 1) {
-        listOfTweets = {
-          name: result.Items[0].name,
-          handle: result.Items[0].handle,
-          location: result.Items[0].location,
-          description: result.Items[0].description,
-          followers_count: result.Items[0].followers_count,
-          friends_count: result.Items[0].friends_count,
-          favourites_count: result.Items[0].favourites_count,
-          following: result.Items[0].following,
-        };
-      }
+    if (result.Items.length >= 1) {
+      listOfTweets = {
+        name: result.Items[0].name,
+        handle: result.Items[0].handle,
+        location: result.Items[0].location,
+        description: result.Items[0].description,
+        followers_count: result.Items[0].followers_count,
+        friends_count: result.Items[0].friends_count,
+        favourites_count: result.Items[0].favourites_count,
+        following: result.Items[0].following,
+      };
+    }
 
-      return listOfTweets;
-    });
-  },
-};
+    return listOfTweets;
+  }
+}
 // eslint-disable-next-line import/prefer-default-export
 export const resolvers = {
   Query: {


### PR DESCRIPTION

noticed that the resolvers in the dynamoDb folder use callbacks and figured since promises are being used everywhere else and project is in es6 you may want to move away from callbacks
documentation here on how AWS sdk supports easily promisifying their sdk methods
https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/using-promises.html

removed promisify utility function
changed dynamoDb api calls to use .promise() so that callback can be removed
made resolver methods use async  await

I'm not sure what the pull request protocol is for this project so let me know if this is something thats wanted and what the right process is to submit a PR